### PR TITLE
Conform to ActiveModel::Serializers' way of determining array-ness

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -13,7 +13,7 @@ module Grape
           @endpoint = env["api.endpoint"]
           options   = endpoint.namespace_options.merge(endpoint.route_options)
 
-          if resource.is_a?(Array) && !resource.empty?
+          if resource.respond_to?(:to_ary) && !resource.empty?
             # ensure we have an root to fallback on
             endpoint.controller_name = resource.first.class.name.underscore.pluralize
           end


### PR DESCRIPTION
I ran into a problem with a model that uses friendly_id where the collection returned was a `FriendlyIdActiveRecordRelation`, which of course did not give the right answer when we asked it `is_a?(Array)`.

So I looked at how ActiveModel::Serializers does its determination of whether a resource is an array, and it calls `respond_to?(:to_ary)` (c.f. https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L274). So I just did the same.
