### PR TITLE
fix default_root method to support symbol route in grape.

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -35,7 +35,7 @@ module Grape
           if innermost_scope[:namespace]
             innermost_scope[:namespace].space
           else
-            endpoint.options[:path][0].split('/')[-1]
+            endpoint.options[:path][0].to_s.split('/')[-1]
           end
         end
       end


### PR DESCRIPTION
make this works fine.

```
get :home do
    # do some thing
end
```
