### PR TITLE
Correctly fetch serialization scope

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -17,7 +17,7 @@ module Grape
           options = build_options_from_endpoint(endpoint)
 
           if serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
-            options[:scope] = serialization_scope unless options.has_key?(:scope)
+            options[:scope] = endpoint.serialization_scope unless options.has_key?(:scope)
             # ensure we have an root to fallback on
             options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
             serializer.new(resource, options.merge(other_options))
@@ -69,10 +69,6 @@ module Grape
           else
             endpoint.options[:path][0].to_s.split('/')[-1]
           end
-        end
-
-        def serialization_scope
-          :current_user
         end
       end
     end

--- a/spec/features/grape-active_model_serializers/render_spec.rb
+++ b/spec/features/grape-active_model_serializers/render_spec.rb
@@ -1,7 +1,4 @@
 require 'spec_helper'
-require 'support/models/user'
-require 'support/serializers/user_serializer'
-require 'grape-active_model_serializers'
 require 'securerandom'
 
 describe '#render' do

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -31,4 +31,24 @@ describe Grape::Formatter::ActiveModelSerializers do
       expect(subject.meta_key).to eq({ meta_key: :custom_key_name })
     end
   end
+
+  describe '.fetch_serializer' do
+    let(:user) { User.new(first_name: 'John') }
+    let(:endpoint) { Grape::Endpoint.new({}, {path: '/', method: 'foo'}) }
+    let(:env) { { 'api.endpoint' => endpoint } }
+
+    before do
+      def endpoint.current_user
+        @current_user ||= User.new(first_name: 'Current user')
+      end
+    end
+
+    subject { described_class.fetch_serializer(user, env) }
+
+    it { should be_a UserSerializer }
+
+    it 'should have correct scope set' do
+      expect(subject.scope).to eq(endpoint.current_user)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'active_support/core_ext/hash/conversions'
 require "active_support/json"
 require 'rspec'
 require 'rack/test'
+require 'grape-active_model_serializers'
 
 require 'jazz_hands'
 


### PR DESCRIPTION
Latest master when used with 0.9.x doesn't correctly handle `scope`, i.e. it passes `:current_user` symbol to the serializer `scope` instead of the value of `current_user` method call.

This fixes this and adds a regression test for it.
