### PR TITLE
Makes it possible to use current_user within serializers

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -17,7 +17,7 @@ module Grape
           options = build_options_from_endpoint(endpoint)
 
           if serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource))
-            options[:scope] = endpoint.serialization_scope unless options.has_key?(:scope)
+            options[:scope] = endpoint unless options.has_key?(:scope)
             # ensure we have an root to fallback on
             options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
             serializer.new(resource, options.merge(other_options))


### PR DESCRIPTION
Setting the scope to the `endpoint` makes it possible to use `current_user` within serializers.

Serializers must delegate `:current_user` to the scope, like this:

```
class BaseSerializer < ActiveModel::Serializer
  delegate :current_user, to: :scope
end
```

I personally use this `BaseSerializer` and then extend all my serializers from this one.
