### PR TITLE
Read default serializer options from the controller

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -56,7 +56,7 @@ module Grape
         end
 
         def build_options_from_endpoint(endpoint)
-          endpoint.namespace_options.merge(endpoint.route_options)
+          [endpoint.default_serializer_options || {}, endpoint.namespace_options, endpoint.route_options].reduce(:merge)
         end
 
         # array root is the innermost namespace name ('space') if there is one,


### PR DESCRIPTION
This allows you to do something like:

``` ruby
helper do
  def default_serializer_options
    {only: params[:only], except: params[:except]}
  end
end
```

And then on any route you could fetch only fields you actually need. There are many other use-cases of course, but this was my main motivation.
