### PR TITLE
Use ActiveModelSerializers::Adapter

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -6,7 +6,7 @@ module Grape
           serializer = fetch_serializer(resource, env)
 
           if serializer
-            serializer.to_json
+            ::ActiveModelSerializers::Adapter.create(serializer).to_json
           else
             Grape::Formatter::Json.call resource, env
           end


### PR DESCRIPTION
Now, nothing happened even if we set ```ActiveModelSerializers.config.adapter``` value.

I think this line (https://github.com/ruby-grape/grape-active_model_serializers/blob/4190cbf18fabca646a08fa1af6ade202454e4e82/lib/grape-active_model_serializers/formatter.rb#L9) should be changed to use ```ActiveModelSerializers.config.adapter``` when it is set.

Seeing these files, 
- https://github.com/rails-api/active_model_serializers#high-level-behavior
- https://github.com/rails-api/active_model_serializers/blob/aad7779a3fd918bed5c17438c4626883d6fe6c5f/lib/active_model_serializers/serializable_resource.rb

we should use ```ActiveModelSerializers::Adapter.create(serializer)``` instead of ```serializer.to_json``` to apply ```ActiveModelSerializers.config.adapter```.

