### PR TITLE
Update codebase to support latest AMS version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
       env: GRAPE_VERSION=HEAD
     - rvm: 2.3.0
     - rvm: 2.2.5
-    - rvm: 2.1
     - rvm: rbx-2
     - rvm: jruby-19mode
     - rvm: ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.5.0 (Next)
 
-* Your contribution here.
+* [#54](https://github.com/ruby-grape/grape-active_model_serializers/pull/54): Adding support for ASM v0.10. Drops support for ASM v0.9 - [@drn](https://github.com/drn).
 
 ### 1.4.0 (July 14, 2016)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ gem 'grape-active_model_serializers'
 
 See [UPGRADING](UPGRADING.md) if you're upgrading from a previous version.
 
+## Dependencies
+
+* >= Ruby v2.2
+* >= [grape](https://github.com/intridea/grape) v0.8.0
+* >= [active_model_serializers](https://github.com/rails-api/active_model_serializers) v0.10.0
+
 ## Usage
 
 ### Require grape-active_model_serializers

--- a/grape-active_model_serializers.gemspec
+++ b/grape-active_model_serializers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.add_dependency 'grape'
-  gem.add_dependency 'active_model_serializers', '>= 0.9.0'
+  gem.add_dependency 'active_model_serializers', '>= 0.10.0'
 
   gem.add_development_dependency 'listen', '~> 3.0.7'
   gem.add_development_dependency 'rspec'

--- a/grape-active_model_serializers.gemspec
+++ b/grape-active_model_serializers.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Grape::ActiveModelSerializers::VERSION
   gem.licenses      = ['MIT']
 
-  gem.add_dependency 'grape'
+  gem.add_dependency 'grape', '>= 0.8.0'
   gem.add_dependency 'active_model_serializers', '>= 0.10.0'
 
   gem.add_development_dependency 'listen', '~> 3.0.7'

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -6,7 +6,7 @@ module Grape
           serializer = fetch_serializer(resource, env)
 
           if serializer
-            serializer.to_json
+            ::ActiveModelSerializers::Adapter.create(serializer).to_json
           else
             Grape::Formatter::Json.call resource, env
           end

--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -3,44 +3,72 @@ module Grape
     module ActiveModelSerializers
       class << self
         def call(resource, env)
-          serializer = fetch_serializer(resource, env)
+          options = build_options(resource, env)
+          serializer = fetch_serializer(resource, options)
 
           if serializer
-            ::ActiveModelSerializers::Adapter.create(serializer).to_json
+            ::ActiveModelSerializers::Adapter.create(
+              serializer, options
+            ).to_json
           else
             Grape::Formatter::Json.call resource, env
           end
         end
 
-        def fetch_serializer(resource, env)
+        def build_options(resource, env)
           endpoint = env['api.endpoint']
           options = build_options_from_endpoint(endpoint)
-          ams_options = {}.tap do |ns|
-            # Extracting declared version from Grape
-            ns[:namespace] = options[:version].try(:classify) if options.try(:[], :version)
-          end
-
-          serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource, ams_options))
-          return nil unless serializer
 
           options[:scope] = endpoint unless options.key?(:scope)
-          # ensure we have an root to fallback on
-          options[:resource_name] = default_root(endpoint) if resource.respond_to?(:to_ary)
-          serializer.new(resource, options.merge(other_options(env)))
+
+          # ensure we have a root to fallback on
+          if resource.respond_to?(:to_ary) && !options.key?(:root)
+            options[:root] = default_root(endpoint)
+          end
+
+          options.merge(meta_options(env))
         end
 
-        def other_options(env)
+        def fetch_serializer(resource, options)
+          # use serializer specified by options
+          serializer = options[:serializer]
+
+          if serializer.nil?
+            # fetch serializer leverage AMS lookup
+            serializer = ActiveModel::Serializer.serializer_for(resource)
+            # if grape version exists, attempt to apply version namespacing
+            serializer = namespace_serializer(serializer, options[:version])
+          end
+
+          return nil unless serializer
+
+          serializer.new(resource, options)
+        end
+
+        def namespace_serializer(serializer, namespace)
+          "#{namespace.try(:classify)}::#{serializer}".constantize
+        rescue NameError
+          serializer
+        end
+
+        def meta_options(env)
           options = {}
           ams_meta = env['ams_meta'] || {}
           meta = ams_meta.delete(:meta)
           meta_key = ams_meta.delete(:meta_key)
           options[:meta_key] = meta_key if meta && meta_key
-          options[meta_key || :meta] = meta if meta
+          options[:meta] = meta if meta
           options
         end
 
         def build_options_from_endpoint(endpoint)
-          [endpoint.default_serializer_options || {}, endpoint.namespace_options, endpoint.route_options, endpoint.options, endpoint.options.fetch(:route_options)].reduce(:merge)
+          [
+            endpoint.default_serializer_options || {},
+            endpoint.namespace_options,
+            endpoint.route_options,
+            endpoint.options,
+            endpoint.options.fetch(:route_options)
+          ].reduce(:merge)
         end
 
         # array root is the innermost namespace name ('space') if there is one,

--- a/spec/features/grape-active_model_serializers/render_spec.rb
+++ b/spec/features/grape-active_model_serializers/render_spec.rb
@@ -5,6 +5,7 @@ describe '#render' do
   let(:app) { Class.new(Grape::API) }
 
   before do
+    ActiveModelSerializers.config.adapter = :json
     app.format :json
     app.formatter :json, Grape::Formatter::ActiveModelSerializers
   end

--- a/spec/grape-active_model_serializers/formatter_spec.rb
+++ b/spec/grape-active_model_serializers/formatter_spec.rb
@@ -44,7 +44,10 @@ describe Grape::Formatter::ActiveModelSerializers do
       end
     end
 
-    subject { described_class.fetch_serializer(user, env) }
+    let(:options) { described_class.build_options(user, env) }
+    subject { described_class.fetch_serializer(user, options) }
+
+    let(:instance_options) { subject.instance_variable_get(:@instance_options) }
 
     it { should be_a UserSerializer }
 
@@ -53,8 +56,8 @@ describe Grape::Formatter::ActiveModelSerializers do
     end
 
     it 'should read default serializer options' do
-      expect(subject.instance_variable_get('@only')).to eq([:only])
-      expect(subject.instance_variable_get('@except')).to eq([:except])
+      expect(instance_options[:only]).to eq(:only)
+      expect(instance_options[:except]).to eq(:except)
     end
 
     it 'should read serializer options like "root"' do

--- a/spec/grape-active_model_serializers/versioned_api_formatter_spec.rb
+++ b/spec/grape-active_model_serializers/versioned_api_formatter_spec.rb
@@ -46,7 +46,10 @@ describe Grape::Formatter::ActiveModelSerializers do
         end
       end
 
-      subject { described_class.fetch_serializer(user, env) }
+      let(:options) { described_class.build_options(user, env) }
+      subject { described_class.fetch_serializer(user, options) }
+
+      let(:instance_options) { subject.instance_variable_get(:@instance_options) }
 
       it { should be_a V1::UserSerializer }
 
@@ -55,8 +58,8 @@ describe Grape::Formatter::ActiveModelSerializers do
       end
 
       it 'should read default serializer options' do
-        expect(subject.instance_variable_get('@only')).to eq([:only])
-        expect(subject.instance_variable_get('@except')).to eq([:except])
+        expect(instance_options[:only]).to eq(:only)
+        expect(instance_options[:except]).to eq(:except)
       end
 
       it 'should read serializer options like "root"' do

--- a/spec/old_grape_ams_spec.rb
+++ b/spec/old_grape_ams_spec.rb
@@ -10,6 +10,7 @@ describe Grape::ActiveModelSerializers do
   subject { last_response.body }
 
   before do
+    ActiveModelSerializers.config.adapter = :json
     app.format :json
     app.formatter :json, Grape::Formatter::ActiveModelSerializers
   end

--- a/spec/support/models/blog_post.rb
+++ b/spec/support/models/blog_post.rb
@@ -1,6 +1,11 @@
 class BlogPost
-  include ActiveModel::SerializerSupport
+  include ActiveModel::Serialization
+
   attr_accessor :title, :body
+
+  def self.model_name
+    to_s
+  end
 
   def initialize(params = {})
     params.each do |k, v|

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,6 +1,11 @@
 class User
-  include ActiveModel::SerializerSupport
+  include ActiveModel::Serialization
+
   attr_accessor :first_name, :last_name, :password, :email
+
+  def self.model_name
+    to_s
+  end
 
   def initialize(params = {})
     params.each do |k, v|


### PR DESCRIPTION
There were a number of changes in the current ActiveModelSerializers versions that broke the functionality of this library. These changes should fix them.

This addresses @dblock's comment raised here https://github.com/ruby-grape/grape-active_model_serializers/pull/53 and should solve this outstanding issue https://github.com/ruby-grape/grape-active_model_serializers/issues/52

Specs were failing for ruby v2.1 because the latest rack requires >= ruby v2.2.2. `Gem::InstallError: rack requires Ruby version >= 2.2.2.` I pushed up a commit to make this pull green, but I'm not sure what the best approach is: dropping ruby 2.1 support or locking rack. Let me know if you'd like me to swap this.