### PR TITLE
Fix

### DIFF
--- a/lib/grape-active_model_serializers/formatter.rb
+++ b/lib/grape-active_model_serializers/formatter.rb
@@ -20,7 +20,12 @@ module Grape
             ns[:namespace] = options[:version].try(:classify) if options.try(:[], :version)
           end
 
-          serializer = options.fetch(:serializer, ActiveModel::Serializer.serializer_for(resource, ams_options))
+          serializer = if options[:serializer]
+                         options[:serializer]
+                       else
+                         ActiveModel::Serializer.serializer_for(resource, ams_options)
+                       end
+
           return nil unless serializer
 
           options[:scope] = endpoint unless options.key?(:scope)


### PR DESCRIPTION
`ActiveModel::Serializer.serializer_for(resource, ams_options))` called even if `options[:serializer]` exists. This causes some strange behavior. 
Here is example. 
Lets assume we have model `User` and serializer `UserSerializer` in module V1 (model is in no module, serializer is in `serializers/v1/user_serializer.rb` file).
And we have simple api for user:
```
get '/', serializer: V1::UserSerializer do
  user = User.find 1
  user
end
```
In that case, Grape-AMS  will trying to load `UserSerializer` (on the assumption of model name). AMS can find file `user_serializer.rb`, but he can't get const `UserSerializer` in this file, because in this file we have `V1::UserSerializer` const, so we get error `'Unable to autoload constant UserSerializer, expected /.../serializers/v1/user_serializer.rb to define it'`. 
But we already specified that we want `V1::UserSerializer`.
If we specify some other serializer, `V1::OtherSerializer` or just `WithoutModuleSerializer`, we will get this error again.