### PR TITLE
Namespace inferred serializer resolution.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from: .rubocop_todo.yml
+
 AllCops:
   Exclude:
     - Guardfile
     - grape-active_model_serializers.gemspec
+
+Style/BlockDelimiters:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,3 @@ Style/Documentation:
 # Configuration parameters: Exclude.
 Style/FileName:
   Enabled: false
-
-# Offense count: 4
-Style/RegexpLiteral:
-  MaxSlashes: 0

--- a/grape-active_model_serializers.gemspec
+++ b/grape-active_model_serializers.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'guard-rspec'
-  gem.add_development_dependency 'rubocop', '0.28.0'
+  gem.add_development_dependency 'rubocop'
 end

--- a/lib/grape-active_model_serializers/endpoint_extension.rb
+++ b/lib/grape-active_model_serializers/endpoint_extension.rb
@@ -9,7 +9,7 @@ module Grape
     attr_accessor :controller_name
 
     def namespace_options
-      if self.respond_to?(:inheritable_setting)
+      if respond_to?(:inheritable_setting)
         inheritable_setting.namespace
       else
         settings[:namespace] ? settings[:namespace].options : {}
@@ -17,7 +17,7 @@ module Grape
     end
 
     def route_options
-      if self.respond_to?(:inheritable_setting)
+      if respond_to?(:inheritable_setting)
         inheritable_setting.route
       else
         options[:route_options]

--- a/lib/grape-active_model_serializers/options_builder.rb
+++ b/lib/grape-active_model_serializers/options_builder.rb
@@ -9,7 +9,7 @@ module Grape
       def options
         @options ||= (
           options = endpoint_options
-          options.merge!(scope: endpoint) unless options.key?(:scope)
+          options[:scope] = endpoint unless options.key?(:scope)
           options.merge!(default_root_options) unless options.key?(:root)
           options.merge!(meta_options)
           options

--- a/lib/grape-active_model_serializers/version.rb
+++ b/lib/grape-active_model_serializers/version.rb
@@ -1,5 +1,5 @@
 module Grape
   module ActiveModelSerializers
-    VERSION = '1.4.0'
+    VERSION = '1.4.0'.freeze
   end
 end

--- a/spec/grape/active_model_serializers/serializer_resolver_spec.rb
+++ b/spec/grape/active_model_serializers/serializer_resolver_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+# asserts serializer resolution order:
+#   1. resource_defined_class     # V1::UserSerializer
+#   2. collection_class           # CollectionSerializer
+#   3. options[:serializer]       # V2::UserSerializer
+#   4. namespace_inferred_class   # V3::UserSerializer
+#   5. version_inferred_class     # V4::UserSerializer
+#   6. resource_serializer_class  # UserSerializer
+#   7. missing resource           # nil
+
+describe Grape::ActiveModelSerializers::SerializerResolver do
+  let(:resolver) { described_class.new(resource, options) }
+  let(:resource) { User.new }
+  let(:options) {
+    {
+      serializer: options_serializer_class, # options defined
+      for:        V3::UsersApi,             # namespace inference
+      version:    'v4'                      # version inference
+    }
+  }
+  # resource defined
+  let(:resource_defined?) { true }
+  let(:defined_serializer_class) { V1::UserSerializer }
+  # options defined
+  let(:options_serializer_class) { V2::UserSerializer }
+
+  let(:serializer) { resolver.serializer }
+
+  before do
+    if resource_defined?
+      allow(resource).to receive(:respond_to?).and_call_original
+      allow(resource).to receive(:respond_to?).with(:to_ary) { true }
+      allow(resource).to receive(:serializer_class) { defined_serializer_class }
+    end
+  end
+
+  context 'resource defined' do
+    it 'returns serializer' do
+      expect(serializer).to be_kind_of(defined_serializer_class)
+    end
+  end
+
+  context 'not resource defined' do
+    let(:resource_defined?) { false }
+
+    context 'resource collection' do
+      let(:resource) { [User.new] }
+      let(:serializer_class) { ActiveModel::Serializer::CollectionSerializer }
+
+      it 'returns serializer' do
+        expect(serializer).to be_kind_of(serializer_class)
+      end
+    end
+
+    context 'not resource collection' do
+      context 'specified by options' do
+        it 'returns specified serializer' do
+          expect(serializer).to be_kind_of(V2::UserSerializer)
+        end
+      end
+
+      context 'not specified by options' do
+        let(:options) { super().except(:serializer) }
+
+        context 'namespace inferred' do
+          it 'returns inferred serializer' do
+            expect(serializer).to be_kind_of(V3::UserSerializer)
+          end
+        end
+
+        context 'not namespace inferred' do
+          let(:options) { super().except(:for) }
+
+          context 'version inferred' do
+            it 'returns inferred serializer' do
+              expect(serializer).to be_kind_of(V4::UserSerializer)
+            end
+          end
+
+          context 'not version inferred' do
+            let(:options) { super().except(:version) }
+
+            context 'ASM resolved' do
+              it 'returns serializer' do
+                expect(serializer).to be_kind_of(UserSerializer)
+              end
+            end
+
+            context 'not ASM resolved' do
+              let(:resource) { nil }
+
+              it 'returns nil' do
+                expect(serializer).to eq(nil)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api/users_api.rb
+++ b/spec/support/api/users_api.rb
@@ -1,0 +1,13 @@
+class UsersApi < Grape::API
+  resource :users do
+    desc 'all users'
+    get do
+      [User.new]
+    end
+
+    desc 'specified user'
+    get '/:id' do
+      User.new
+    end
+  end
+end

--- a/spec/support/api/v3/users_api.rb
+++ b/spec/support/api/v3/users_api.rb
@@ -1,0 +1,15 @@
+module V3
+  class UsersApi < Grape::API
+    resource :users do
+      desc 'all users'
+      get do
+        [User.new]
+      end
+
+      desc 'specified user'
+      get '/:id' do
+        User.new
+      end
+    end
+  end
+end

--- a/spec/support/serializers/v2/user_serializer.rb
+++ b/spec/support/serializers/v2/user_serializer.rb
@@ -1,0 +1,5 @@
+module V2
+  class UserSerializer < ActiveModel::Serializer
+    attributes :first_name, :last_name, :email
+  end
+end

--- a/spec/support/serializers/v3/user_serializer.rb
+++ b/spec/support/serializers/v3/user_serializer.rb
@@ -1,0 +1,5 @@
+module V3
+  class UserSerializer < ActiveModel::Serializer
+    attributes :first_name, :last_name, :email
+  end
+end

--- a/spec/support/serializers/v4/user_serializer.rb
+++ b/spec/support/serializers/v4/user_serializer.rb
@@ -1,0 +1,5 @@
+module V4
+  class UserSerializer < ActiveModel::Serializer
+    attributes :first_name, :last_name, :email
+  end
+end


### PR DESCRIPTION
This reimplements the changes in pull https://github.com/ruby-grape/grape-active_model_serializers/pull/58 on top of the refactor of pull https://github.com/ruby-grape/grape-active_model_serializers/pull/59.

This borrows some logic from the [serializer resolution logic in active_model_serializers](https://github.com/rails-api/active_model_serializers/blob/master/lib/active_model/serializer.rb#L34). Given that active_model_serializers no longer supports the `namespace` option passed into the `serializer_for` method, in order to support namespace inference we need to reuse some of their `serializer_for` logic in grape-asm. I will work with the asm team to add back support for that option, but in order to support the existing 0.10.x asm versions, we need to reimplement some of that logic.